### PR TITLE
fix complile issue with conda

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,6 @@ export BUILD_TYPE="release"
 
 export EXTRA_CMAKE_OPTIONS="$EXTRA_CMAKE_OPTIONS -DBoost_NO_BOOST_CMAKE=on"
 
-export DIR_="/home/kunshang/dev/omniscidb/scripts/conda/"
 . ${DIR_}/get_cxx_include_path.sh
 export CPLUS_INCLUDE_PATH=$(get_cxx_include_path)
 

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -65,8 +65,8 @@ export CPLUS_INCLUDE_PATH=$(get_cxx_include_path)
 # generate ~/.m2/settings.xml if proxy are set and there are no settings
 [ -f ~/.m2/settings.xml -o -z "$http_proxy" ] || python ${RECIPE_DIR}/make-m2-proxy.py
 
-mkdir -p build-p
-cd build-p
+mkdir -p build
+cd build
 
 cmake -Wno-dev \
     -DCMAKE_PREFIX_PATH=$PREFIX \


### PR DESCRIPTION
Some issue when I compile this branch.

redundant export DIR_ in build script. We can export DIR_ in the machine instead of hard code it.

in conda build script, create build dir build-p will cause make sanity-test failure. sanity-test will still search cmake file from .../build/...cmake instead of .../build-p/...cmake

