### PR TITLE
add namespace to avoid 'not declared in this scope'

### DIFF
--- a/QueryEngine/CiderCodeGenerator.cpp
+++ b/QueryEngine/CiderCodeGenerator.cpp
@@ -2861,7 +2861,7 @@ CiderCodeGenerator::compileWorkUnit(const std::vector<InputTableInfo>& query_inf
                                    : "");
 
 #ifndef NDEBUG
-    llvm_ir += serialize_llvm_metadata_footnotes(query_func, cgen_state_.get());
+    llvm_ir += cider::serialize_llvm_metadata_footnotes(query_func, cgen_state_.get());
 #endif
   }
 


### PR DESCRIPTION
Issue happend when compile without conda 

/home/yuqiang/OpenSource/IntelBigData/omniscidb/QueryEngine/CiderCodeGenerator.cpp: In member function ‘std::tuple<CompilationResult, std::unique_ptr<QueryMemoryDescriptor, std::default_delete<QueryMemoryDescriptor> > > CiderCodeGenerator::compileWorkUnit(const std::vector<InputTableInfo>&, const DeletedColumnsMap&, const RelAlgExecutionUnit&, const CompilationOptions&, const ExecutionOptions&, const CudaMgr_Namespace::CudaMgr*, bool, std::shared_ptr<RowSetMemoryOwner>, size_t, int8_t, bool, ColumnCacheMap&, RenderInfo*)’:
/home/yuqiang/OpenSource/IntelBigData/omniscidb/QueryEngine/CiderCodeGenerator.cpp:2864:16: error: ‘serialize_llvm_metadata_footnotes’ was not declared in this scope
     llvm_ir += serialize_llvm_metadata_footnotes(query_func, cgen_state_.get());
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
