### PR TITLE
Fix for arrow5

### DIFF
--- a/Embedded/EmbeddedDbTest.cpp
+++ b/Embedded/EmbeddedDbTest.cpp
@@ -68,11 +68,11 @@ int main(int argc, char* argv[]) {
   try {
     auto opt_str = base_path + " --calcite-port " + std::to_string(calcite_port);
     if (columnar_output) {
-      opt_str += "--columnar-output";
+      opt_str += " --columnar-output";
     }
     auto dbe = DBEngine::create(opt_str);
     if (dbe) {
-      auto memory_pool = arrow::default_memory_pool();
+      arrow::io::IOContext io_context = arrow::io::default_io_context();
       auto arrow_parse_options = arrow::csv::ParseOptions::Defaults();
       auto arrow_read_options = arrow::csv::ReadOptions::Defaults();
       auto arrow_convert_options = arrow::csv::ConvertOptions::Defaults();
@@ -80,7 +80,7 @@ int main(int argc, char* argv[]) {
       auto file_result = arrow::io::ReadableFile::Open("/localdisk/artemale/test.csv");
       ARROW_THROW_NOT_OK(file_result.status());
       inp = file_result.ValueOrDie();
-      auto table_reader_result = arrow::csv::TableReader::Make(memory_pool,
+      auto table_reader_result = arrow::csv::TableReader::Make(io_context,
                                                                inp,
                                                                arrow_read_options,
                                                                arrow_parse_options,

--- a/ImportExport/ForeignDataImporter.cpp
+++ b/ImportExport/ForeignDataImporter.cpp
@@ -34,7 +34,7 @@ ForeignDataImporter::ForeignDataImporter(const std::string& file_path,
 void ForeignDataImporter::finalize(
     const Catalog_Namespace::SessionInfo& parent_session_info,
     ImportStatus& import_status,
-    const std::vector<std::pair<const ColumnDescriptor*, StringDictionary*> >&
+    const std::vector<std::pair<const ColumnDescriptor*, StringDictionary*>>&
         string_dictionaries) {
   if (table_->persistenceLevel ==
       Data_Namespace::MemoryLevel::DISK_LEVEL) {  // only checkpoint disk-resident


### PR DESCRIPTION
cherry picked from commit 99d34fa16edd058886177a819e5a3e143f16b387

-DENABLE_ARROW_4=ON does not work in jenkins test server though cider branch are also using arrow 5
After cherry picked the commit from master, cider branch will build success and CompileWorkUnitTest passed

cmake build command: 
cmake -DENABLE_CUDA=off -DENABLE_DBE=ON -DENABLE_TESTS=on -DRAPIDJSON_HAS_STDSTRING=ON ..

root@r18s06:/var/lib/jenkins/workspace/OMNISCIDB/build/Tests# ./CompileWorkUnitTest
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from APITest
[ RUN      ] APITest.case1
2021-12-10T12:48:42.543698 1 1119709 0 0 NativeCodegen.cpp:2790 number of hoisted literals: 1 / literal buffer usage: 8 bytes
total match 5 rows
[       OK ] APITest.case1 (31 ms)
[----------] 1 test from APITest (31 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (32 ms total)
[  PASSED  ] 1 test.

