### PR TITLE
[POAE7-1458] Bugs fix for installing scripts

### DIFF
--- a/scripts/llvm-9-glibc-2.31-708430.patch
+++ b/scripts/llvm-9-glibc-2.31-708430.patch
@@ -1,12 +1,14 @@
----compiler - rt / lib / sanitizer_common / sanitizer_platform_limits_posix.cc.orig 2020 -
-    03 - 11 20 : 35 : 37.099808821 + 0100 +++compiler -
-    rt / lib / sanitizer_common / sanitizer_platform_limits_posix.cc 2020 - 03 -
-    11 20 : 36 : 08.279808758 + 0100 @ @-1128,
-    7 + 1128, 7 @ @CHECK_SIZE_AND_OFFSET(ipc_perm, cgid);
-#if !defined(__aarch64__) || !SANITIZER_LINUX || __GLIBC_PREREQ(2, 21)
-/* On aarch64 glibc 2.20 and earlier provided incorrect mode field.  */
-- CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
-+  // CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
-#endif
-
-    CHECK_TYPE_SIZE(shmid_ds);
+diff --git a/sanitizer_platform_limits_posix.cc.orig b/sanitizer_platform_limits_posix.cc
+index b7fa6e8..2c42ece 100644
+--- compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc.orig
++++ compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -1128,7 +1128,7 @@ CHECK_SIZE_AND_OFFSET(ipc_perm, cuid);
+ CHECK_SIZE_AND_OFFSET(ipc_perm, cgid);
+ #if !defined(__aarch64__) || !SANITIZER_LINUX || __GLIBC_PREREQ (2, 21)
+ /* On aarch64 glibc 2.20 and earlier provided incorrect mode field.  */
+-CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
++//CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
+ #endif
+ 
+ CHECK_TYPE_SIZE(shmid_ds);
+ 


### PR DESCRIPTION
Omnisci use this file to patch llvm 9 for glibc 2.31+ support. The original patch file can't be parsed successfully and are considered as garbage. This updated patch is generated by command 'git diff', which can be used by
`sudo patch -p0 < $SCRIPTS_DIR/llvm-9-glibc-2.31-708430.patch`
(line 193 in https://github.com/Intel-bigdata/omniscidb/blob/master/scripts/common-functions.sh)